### PR TITLE
Fix undefined format parameter

### DIFF
--- a/service.js
+++ b/service.js
@@ -79,7 +79,6 @@ function PluginService(){
           end_date,
           options: {
             range_max: moment(end_date).diff(moment(start_date), stepunit) - 1,
-            format,
             step, //added
             stepunit,
             stepunitmultiplier,


### PR DESCRIPTION
Removed a old setting **format** parameter, no more used in layer qtimeseries configuration.
